### PR TITLE
Switch to authenticating to the GitHub API via authorization request header

### DIFF
--- a/lib/github_workflow/version.rb
+++ b/lib/github_workflow/version.rb
@@ -1,3 +1,3 @@
 module GithubWorkflow
-  VERSION = "0.3.3"
+  VERSION = "0.3.5"
 end


### PR DESCRIPTION
## Problem

GitHub is removing authenticating with their API via query params.

<img width="1040" alt="Screen Shot 2021-05-05 at 11 21 27 AM" src="https://user-images.githubusercontent.com/6352760/117166122-142a1780-ad94-11eb-9673-cc0152855954.png">


## Proposed Solution

As per [their post on the matter](https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/), the solution is to switch to send the access token via the authorization request header.

## Misc

I am using this version of the gem in my workflow for testing.
