### PR TITLE
Remove --quiet flag when popping stash

### DIFF
--- a/lib/github_workflow/cli.rb
+++ b/lib/github_workflow/cli.rb
@@ -383,7 +383,8 @@ module GithubWorkflow
       def stash_pop
         if @stashed
           say_info("Stash pop")
-          `git stash pop --quiet`
+          `git stash pop`
+          nil
         end
       end
 

--- a/lib/github_workflow/version.rb
+++ b/lib/github_workflow/version.rb
@@ -1,3 +1,3 @@
 module GithubWorkflow
-  VERSION = "0.3.6"
+  VERSION = "0.3.7"
 end


### PR DESCRIPTION
Fixes https://github.com/daisybill/github_workflow/issues/3, "git stages deletes of all files and untracks all files when starting new story" by doing exactly what the [overcommit maintainers did](https://github.com/sds/overcommit/commit/648383ff3cd9d51ab83de87f2bf64fa9a0d6d559) which was to remove the `--quiet` flag when popping git stash.

